### PR TITLE
Exit focely

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ require "sidekiq/recycler"
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add Sidekiq::Recycler, :mem_limit => 300_000, :hard_limit_sec => 300
+    chain.add Sidekiq::Recycler, :mem_limit => 300_000, :hard_limit_sec => 300, :exit_limit_sec => 600
   end
 end
 ```
@@ -34,8 +34,8 @@ end
 Two options are exposed by the middleware:
 
  * mem_limit: RSS usage limit, in megabytes
- * hard_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated
-
+ * hard_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Send TERM signal
+ * exit_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Exit forcely.
 
 ## Kick the tires
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ require "sidekiq/recycler"
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add Sidekiq::Recycler, :mem_limit => 300_000, :hard_limit_sec => 300, :exit_limit_sec => 600
+    chain.add Sidekiq::Recycler, :mem_limit => 300_000, :soft_limit_sec => 300, :hard_limit_sec => 600
   end
 end
 ```
@@ -34,8 +34,8 @@ end
 Two options are exposed by the middleware:
 
  * mem_limit: RSS usage limit, in megabytes
- * hard_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Send TERM signal
- * exit_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Exit forcely.
+ * soft_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Send TERM signal
+ * hard_limit_sec: time in seconds to wait for jobs to finish, after graceful shutdown initiated. Exit forcely
 
 ## Kick the tires
 


### PR DESCRIPTION
I met situations that busy Processor threads block to exit, and sending TERM signal again does not let sidekiq finish anymore. 

So, I added and changed options as
- soft_limit_sec: send TERM
- hard_limit_sec: exit forcely

I referred sidekiq codes and it was doing the same thing at https://github.com/mperham/sidekiq/blob/2fc1d81cc9691c9232a088f1410c5a27fae5e11f/lib/sidekiq/cli.rb#L94-L96 like

``` ruby
        # Explicitly exit so busy Processor threads can't block
        # process shutdown.
        exit(0)
```
